### PR TITLE
Update glam to match Bevy's version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default=[]
 bevy=["dep:bevy"]
 
 [dependencies]
-glam = "0.25"
+glam = "0.27.0"
 hashbrown = "0.14"
 image = "0.25"
 mashmap = "0.1"


### PR DESCRIPTION
Otherwise, if included in a project that depends on Bevy, both versions of Glam are pulled in, resulting in mismatched types.

I've also updated [bevy_collider_gen](https://github.com/tnajdek/bevy_collider_gen) to Bevy 0.14, but that update depends on this one.