### PR TITLE
Update to bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pedantic = { level = "warn", priority = 0 }
 [features]
 default = ["bevy"]
 glam-latest = ["dep:glam"]
-bevy = ["dep:bevy_math", "dep:bevy_render"]
+bevy = ["dep:bevy_math", "dep:bevy_image"]
 
 [dependencies]
 image = "0.25"
@@ -32,18 +32,23 @@ version = "0.29"
 optional = true
 
 [dependencies.bevy_math]
-version = "0.14"
+version = "0.15"
 default-features = false
 optional = true
 
-[dependencies.bevy_render]
-version = "0.14"
+[dependencies.bevy_image]
+version = "0.15"
 default-features = false
+features = ["png"]
 optional = true
 
 [dev-dependencies]
 raqote = "0.8"
 open = "5.1"
+
+[dev-dependencies.bevy_render]
+version = "0.15"
+default-features = false
 
 [[example]]
 name = "bevy-image"

--- a/examples/bevy-image.rs
+++ b/examples/bevy-image.rs
@@ -53,23 +53,23 @@ fn draw_png(image: &Image, img_path: &str) {
 
     let scale = 8;
     let (width, height) = (
-        i32::try_from(image.width()).expect("Image to wide.") * scale,
-        i32::try_from(image.height()).expect("Image to tall.") * scale,
+        i32::try_from(image.width() * scale).expect("Image to wide."),
+        i32::try_from(image.height() * scale).expect("Image to tall."),
     );
 
     // draw the edges to a png
     let mut dt = DrawTarget::new(width, height);
 
-    let objects = edges.multi_image_edges_raw();
+    let objects = edges.multi_image_edge_raw();
 
     for object in objects {
         let mut pb = PathBuilder::new();
         let mut edges_iter = object.into_iter();
 
         if let Some(first_edge) = edges_iter.next() {
-            pb.move_to(first_edge.x * scale as f32, first_edge.y * scale as f32);
+            pb.move_to((first_edge.x * scale) as f32, (first_edge.y * scale) as f32);
             for edge in edges_iter {
-                pb.line_to(edge.x * scale as f32, edge.y * scale as f32);
+                pb.line_to((edge.x * scale) as f32, (edge.y * scale) as f32);
             }
         }
 

--- a/examples/bevy-image.rs
+++ b/examples/bevy-image.rs
@@ -80,7 +80,7 @@ fn draw_png(image: &Image, img_path: &str) {
                 a: 0xff,
             }),
             &StrokeStyle {
-                width: 1.,
+                width: scale as f32,
                 ..StrokeStyle::default()
             },
             &DrawOptions::new(),

--- a/examples/bevy-image.rs
+++ b/examples/bevy-image.rs
@@ -1,8 +1,5 @@
-use bevy_render::{
-    prelude::Image,
-    render_asset::RenderAssetUsages,
-    texture::{CompressedImageFormats, ImageSampler, ImageType},
-};
+use bevy_image::{prelude::Image, CompressedImageFormats, ImageSampler, ImageType};
+use bevy_render::render_asset::RenderAssetUsages;
 use edges::Edges;
 use raqote::{DrawOptions, DrawTarget, PathBuilder, SolidSource, Source, StrokeStyle};
 // in an actual bevy app, you wouldn't need all this building an Image from scratch logic,

--- a/examples/dynamic-image.rs
+++ b/examples/dynamic-image.rs
@@ -15,8 +15,8 @@ fn draw_png(img_path: &str) {
 
     let scale = 8;
     let (width, height) = (
-        i32::try_from(image.width()).expect("Image to wide.") * scale,
-        i32::try_from(image.height()).expect("Image to tall.") * scale,
+        i32::try_from(image.width() * scale).expect("Image to wide."),
+        i32::try_from(image.height() * scale).expect("Image to tall."),
     );
 
     // draw the edges to a png
@@ -25,9 +25,9 @@ fn draw_png(img_path: &str) {
 
     let mut edges_iter = edges.single_image_edge_raw().into_iter();
     let first_edge = edges_iter.next().unwrap();
-    pb.move_to(first_edge.x * scale as f32, first_edge.y * scale as f32);
+    pb.move_to((first_edge.x * scale) as f32, (first_edge.y * scale) as f32);
     for edge in edges_iter {
-        pb.line_to(edge.x * scale as f32, edge.y * scale as f32);
+        pb.line_to((edge.x * scale) as f32, (edge.y * scale) as f32);
     }
 
     let path = pb.finish();

--- a/examples/dynamic-image.rs
+++ b/examples/dynamic-image.rs
@@ -40,7 +40,7 @@ fn draw_png(img_path: &str) {
             a: 0xff,
         }),
         &StrokeStyle {
-            width: 1.,
+            width: scale as f32,
             ..StrokeStyle::default()
         },
         &DrawOptions::new(),

--- a/src/bin_image.rs
+++ b/src/bin_image.rs
@@ -123,7 +123,7 @@ impl BinImage {
     }
 
     pub fn is_corner(&self, p: UVec2) -> bool {
-        is_corner(self.get_neighbors(p))
+        self.get(p) && is_corner(self.get_neighbors(p))
     }
 
     /// Translates a point in positive (x, y) coordinates to a coordinate system centered at (0, 0).

--- a/src/bin_image.rs
+++ b/src/bin_image.rs
@@ -14,7 +14,7 @@ pub mod neighbors {
 }
 
 /// A struct representing a binary image.
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BinImage {
     data: Vec<u8>,
     height: u32,

--- a/src/bin_image.rs
+++ b/src/bin_image.rs
@@ -137,8 +137,8 @@ impl BinImage {
     /// A new `Vec2` representing the translated coordinates
     const fn translate_point(&self, p: UVec2) -> Vec2 {
         Vec2::new(
-            (p.x - self.width / 2 - 1) as f32,
-            (self.height / 2 - p.y - 1) as f32,
+            p.x as f32 - (self.width / 2) as f32,
+            (self.height / 2) as f32 - p.y as f32,
         )
     }
 

--- a/src/bin_image.rs
+++ b/src/bin_image.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::{utils::is_corner, UVec2, Vec2};
 use rayon::prelude::*;
 pub mod neighbors {
@@ -11,6 +13,8 @@ pub mod neighbors {
     pub const SOUTHWEST: u8 = 0b0000_0001;
 }
 
+/// A struct representing a binary image.
+#[derive(Debug)]
 pub struct BinImage {
     data: Vec<u8>,
     height: u32,
@@ -157,5 +161,22 @@ impl BinImage {
 
     pub const fn width(&self) -> u32 {
         self.width
+    }
+
+}
+
+impl Display for BinImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for y in 0..self.height() {
+            for x in 0..self.width() {
+                if self.get(UVec2::new(x, y)) {
+                    write!(f, "█")?;
+                } else {
+                    write!(f, "-")?;
+                }
+            }
+            writeln!(f)?;
+        }
+        Ok(())
     }
 }

--- a/src/bin_image.rs
+++ b/src/bin_image.rs
@@ -86,10 +86,6 @@ impl BinImage {
 
     /// Gets the values of the neighboring pixels (8-connectivity) around the given coordinate.
     ///
-    /// # Arguments
-    ///
-    /// * `p` - A `UVec2` representing the coordinates of the center pixel.
-    ///
     /// # Returns
     ///
     /// An byte representing the state of the neighboring pixels.
@@ -129,10 +125,6 @@ impl BinImage {
 
     /// Translates a point in positive (x, y) coordinates to a coordinate system centered at (0, 0).
     ///
-    /// # Arguments
-    ///
-    /// * `p` - A `Vec2` representing the point to translate.
-    ///
     /// # Returns
     ///
     /// A new `Vec2` representing the translated coordinates
@@ -144,10 +136,6 @@ impl BinImage {
     }
 
     /// Translates an `Vec` of points in positive (x, y) coordinates to a coordinate system centered at (0, 0).
-    ///
-    /// # Arguments
-    ///
-    /// * `v` - An `Vec` of `Vec2` points to translate.
     ///
     /// # Returns
     ///
@@ -163,7 +151,6 @@ impl BinImage {
     pub const fn width(&self) -> u32 {
         self.width
     }
-
 }
 
 impl Display for BinImage {

--- a/src/bin_image.rs
+++ b/src/bin_image.rs
@@ -131,10 +131,10 @@ impl BinImage {
     /// # Returns
     ///
     /// A new `Vec2` representing the translated coordinates
-    fn translate_point(&self, p: Vec2) -> Vec2 {
+    const fn translate_point(&self, p: UVec2) -> Vec2 {
         Vec2::new(
-            p.x - ((self.width / 2) as f32 - 1.0),
-            ((self.height / 2) as f32 - 1.0) - p.y,
+            (p.x - self.width / 2 - 1) as f32,
+            (self.height / 2 - p.y - 1) as f32,
         )
     }
 
@@ -147,7 +147,7 @@ impl BinImage {
     /// # Returns
     ///
     /// A vector of `Vec2` representing the translated coordinates.
-    pub fn translate(&self, v: Vec<Vec2>) -> Vec<Vec2> {
+    pub fn translate(&self, v: Vec<UVec2>) -> Vec<Vec2> {
         v.into_par_iter().map(|p| self.translate_point(p)).collect()
     }
 

--- a/src/bin_image.rs
+++ b/src/bin_image.rs
@@ -35,7 +35,7 @@ impl BinImage {
     ///
     /// This function will panic if the length of `data` is less than `height * width`.
     pub fn new(height: u32, width: u32, data: &[u8]) -> Self {
-        assert!(
+        debug_assert!(
             data.len() >= (height * width) as usize,
             "data must not be smaller than image dimensions"
         );
@@ -68,18 +68,19 @@ impl BinImage {
     /// Returns `true` if the pixel is "on" (1), and `false` if it is "off" (0) or out of bounds.
     pub fn get(&self, p: UVec2) -> bool {
         if p.x >= self.width {
-            return false;
-        }
-        let index = p.y * self.width + p.x;
-        if let Some(mut byte) = self
-            .data
-            .get((index / 8) as usize) // index of byte
-            .copied()
-        {
-            byte >>= index % 8; // index of bit
-            byte & 1 > 0
-        } else {
             false
+        } else {
+            let index = p.y * self.width + p.x;
+            if let Some(mut byte) = self
+                .data
+                .get((index / 8) as usize) // index of byte
+                .copied()
+            {
+                byte >>= index % 8; // index of bit
+                byte & 1 > 0
+            } else {
+                false
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,15 +216,9 @@ impl From<&image::DynamicImage> for Edges {
 
 impl fmt::Debug for Edges {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Edges {{{}\n}}",
-            format!(
-                "\nraw: {:#?},\ntranslated: {:#?}",
-                self.image_edges(),
-                self.translate_objects(self.image_edges())
-            )
-            .replace('\n', "\n    "),
-        )
+        f.debug_struct("Edges")
+            .field("raw", &self.image_edges())
+            .field("translated", &self.translate_objects(self.image_edges()))
+            .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,12 @@ impl Edges {
     }
 }
 
+impl From<Edges> for Vec<Vec<UVec2>> {
+    fn from(value: Edges) -> Vec<Vec<UVec2>> {
+        value.image_edges()
+    }
+}
+
 #[cfg(feature = "bevy")]
 impl From<bevy_render::prelude::Image> for Edges {
     fn from(i: bevy_render::prelude::Image) -> Edges {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,6 @@ pub struct Edges {
 
 impl Edges {
     /// Creates a new `Edges` instance from the given dimensions and pixel data.
-    ///
-    /// # Arguments
-    ///
-    /// * `height` - The height of the image.
-    /// * `width` - The width of the image.
-    /// * `data` - A slice of bytes representing the pixel data of the image.
-    ///
     #[inline]
     #[must_use]
     pub fn new(height: u32, width: u32, data: &[u8]) -> Self {
@@ -153,10 +146,6 @@ impl Edges {
 
     /// Translates an `Vec` of points in positive (x, y) coordinates to a coordinate system centered at (0, 0).
     ///
-    /// # Arguments
-    ///
-    /// * `v` - An `Vec` of `Vec2` points to translate.
-    ///
     /// # Returns
     ///
     /// A vector of `Vec2` representing the translated coordinates.
@@ -167,10 +156,6 @@ impl Edges {
     }
 
     /// Translates an `Vec` of `Vec` of points in positive (x, y) coordinates to a coordinate system centered at (0, 0).
-    ///
-    /// # Arguments
-    ///
-    /// * `v` - An `Vec` of `Vec2` points to translate.
     ///
     /// # Returns
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,8 +176,8 @@ impl From<Edges> for Vec<Vec<UVec2>> {
 }
 
 #[cfg(feature = "bevy")]
-impl From<bevy_render::prelude::Image> for Edges {
-    fn from(i: bevy_render::prelude::Image) -> Edges {
+impl From<bevy_image::prelude::Image> for Edges {
+    fn from(i: bevy_image::prelude::Image) -> Edges {
         Self::new(i.height(), i.width(), &i.data)
     }
 }
@@ -189,8 +189,8 @@ impl From<image::DynamicImage> for Edges {
 }
 
 #[cfg(feature = "bevy")]
-impl From<&bevy_render::prelude::Image> for Edges {
-    fn from(i: &bevy_render::prelude::Image) -> Edges {
+impl From<&bevy_image::prelude::Image> for Edges {
+    fn from(i: &bevy_image::prelude::Image) -> Edges {
         Self::new(i.height(), i.width(), &i.data)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ mod bin_image;
 mod tests;
 mod utils;
 
+/// A struct representing the edges of a image.
+#[derive(Clone)]
 pub struct Edges {
     image: BinImage,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ impl Edges {
         let corners: Vec<_> = (0..image.height() * image.width())
             .into_par_iter()
             .map(|i| UVec2::new(i / image.height(), i % image.height()))
-            .filter(|p| image.get(*p) && image.is_corner(*p))
+            .filter(|p| image.is_corner(*p))
             .collect();
 
         self.collect_objects(&corners)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,6 @@
 use crate::Edges;
-use bevy_render::{
-    render_asset::RenderAssetUsages,
-    texture::{CompressedImageFormats, Image, ImageSampler, ImageType},
-};
+use bevy_image::{prelude::Image, CompressedImageFormats, ImageSampler, ImageType};
+use bevy_render::render_asset::RenderAssetUsages;
 use std::path::Path;
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,7 @@ fn same_image_same_edges() {
         include_bytes!("../assets/car.png"), // buffer
         ImageType::Extension("png"),
         CompressedImageFormats::default(),
-        true, //
+        true,
         ImageSampler::default(),
         RenderAssetUsages::default(),
     )
@@ -40,7 +40,7 @@ fn same_images_same_edges() {
         include_bytes!("../assets/boulders.png"), // buffer
         ImageType::Extension("png"),
         CompressedImageFormats::default(),
-        true, //
+        true,
         ImageSampler::default(),
         RenderAssetUsages::default(),
     )
@@ -48,8 +48,8 @@ fn same_images_same_edges() {
     let bevy_edges = Edges::from(bevy_image);
 
     assert_eq!(
-        dynamic_edges.multi_image_edges_raw(),
-        bevy_edges.multi_image_edges_raw()
+        dynamic_edges.multi_image_edge_raw(),
+        bevy_edges.multi_image_edge_raw()
     );
     assert_eq!(
         dynamic_edges.multi_image_edge_translated(),


### PR DESCRIPTION
# Added
- `Display`, `Debug`, `Clone` traits for `BinImage`.
- `Clone`, `Into<Vec<Vec<UVec2>>` for `Edges`.
- `translate_objects` method to `Edges`.
- 1 linear functions are marked with the macro `inline`.

# Changed
- refactored `Debug` trait for `Edges`.
- function `multi_image_edges_raw` renamed to `multi_image_edge_raw`.
- width of stroke in examples from 1 to scale factor.
- type of raw output of functions.

# Removed
- `translate` flag for `image_edges` function.