### PR TITLE
Update points translation and centering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ parallel = ["dep:rayon"]
 
 
 [dependencies]
-binary_image = "0.5"
+binary_image = "0.6"
 image = { version = "0.25", default-features = false }
 rayon = { version = "1", optional = true }
 glam = { version = "0.29", optional = true }

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -1,0 +1,60 @@
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use crate::{utils::center, UVec2, Vec2};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum Anchor {
+    Center(u32, u32),
+    VerticalCenter(u32),
+    HorisontalCenter(u32),
+    #[default]
+    AbsoluteCenter,
+}
+
+impl Anchor {
+    #[inline]
+    #[must_use]
+    pub fn center(self) -> Option<UVec2> {
+        match self {
+            Anchor::Center(height, width) => Some(UVec2::new(width, height) / 2),
+            Anchor::VerticalCenter(height) => Some(UVec2::new(0, height / 2)),
+            Anchor::HorisontalCenter(width) => Some(UVec2::new(width / 2, 0)),
+            Anchor::AbsoluteCenter => None,
+        }
+    }
+
+    /// Translates an `Vec` of points in positive (x, y) coordinates to a coordinate system centered at (0, 0).
+    ///
+    /// # Returns
+    ///
+    /// A vector of `Vec2` representing the translated coordinates.
+    #[inline]
+    #[must_use]
+    pub fn translate(self, polygon: Vec<UVec2>) -> Vec<Vec2> {
+        let delta = self
+            .center()
+            .or_else(|| center(polygon.iter().copied()))
+            .unwrap_or(UVec2::ZERO)
+            .as_vec2();
+
+        #[cfg(feature = "parallel")]
+        let iter = polygon.into_par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let iter = polygon.into_iter();
+
+        iter.map(|p| Vec2::new(p.x as f32 - delta.x, delta.y - p.y as f32))
+            .collect()
+    }
+
+    /// Translates an `Vec` of `Vec` of points in positive (x, y) coordinates to a coordinate system centered at (0, 0).
+    ///
+    /// # Returns
+    ///
+    /// A vector of vector of `Vec2` representing the translated objects.
+    #[inline]
+    #[must_use]
+    pub fn translate_polygons(self, polygons: impl Iterator<Item = Vec<UVec2>>) -> Vec<Vec<Vec2>> {
+        polygons.map(|polygon| self.translate(polygon)).collect()
+    }
+}

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crate::{utils::center, UVec2, Vec2};
+use crate::{utils::center_of, UVec2, Vec2};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub enum Anchor {
@@ -15,11 +15,11 @@ pub enum Anchor {
 impl Anchor {
     #[inline]
     #[must_use]
-    pub fn center(self) -> Option<UVec2> {
+    pub fn size(self) -> Option<UVec2> {
         match self {
-            Anchor::Center(height, width) => Some(UVec2::new(width, height) / 2),
-            Anchor::VerticalCenter(height) => Some(UVec2::new(0, height / 2)),
-            Anchor::HorisontalCenter(width) => Some(UVec2::new(width / 2, 0)),
+            Anchor::Center(height, width) => Some(UVec2::new(width, height)),
+            Anchor::VerticalCenter(height) => Some(UVec2::new(0, height)),
+            Anchor::HorisontalCenter(width) => Some(UVec2::new(width, 0)),
             Anchor::AbsoluteCenter => None,
         }
     }
@@ -32,18 +32,16 @@ impl Anchor {
     #[inline]
     #[must_use]
     pub fn translate(self, polygon: Vec<UVec2>) -> Vec<Vec2> {
-        let delta = self
-            .center()
-            .or_else(|| center(polygon.iter().copied()))
-            .unwrap_or(UVec2::ZERO)
-            .as_vec2();
-
+        let center = self.size().map_or_else(
+            || center_of(polygon.iter().copied()).unwrap_or(Vec2::ZERO),
+            |size| size.as_vec2() / 2.,
+        );
         #[cfg(feature = "parallel")]
         let iter = polygon.into_par_iter();
         #[cfg(not(feature = "parallel"))]
         let iter = polygon.into_iter();
 
-        iter.map(|p| Vec2::new(p.x as f32 - delta.x, delta.y - p.y as f32))
+        iter.map(|p| Vec2::new(p.x as f32 - center.x, center.y - p.y as f32))
             .collect()
     }
 

--- a/src/iter/direction.rs
+++ b/src/iter/direction.rs
@@ -19,7 +19,7 @@ pub enum Direction {
 }
 
 impl Direction {
-    pub fn find_by_direction(self, current: UVec2, points: &[UVec2]) -> Option<UVec2> {
+    pub fn find_in(self, current: UVec2, points: &[UVec2]) -> Option<UVec2> {
         #[cfg(not(feature = "parallel"))]
         let iter = points.iter();
         #[cfg(feature = "parallel")]
@@ -63,6 +63,7 @@ impl Direction {
         .copied()
     }
 
+    #[inline]
     pub fn reverse(self) -> Self {
         match self {
             North => South,

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -57,9 +57,7 @@ where
                 current = if previous_direction.reverse() == direction {
                     *object.last().unwrap()
                 } else {
-                    direction
-                        .find_by_direction(current, corners)
-                        .unwrap_or(start)
+                    direction.find_in(current, corners).unwrap_or(start)
                 };
 
                 if *object.last().unwrap() == start && object.contains(&current) {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -28,7 +28,9 @@ where
             corners: (0..height)
                 .rev()
                 .flat_map(|y| (0..width).map(move |x| UVec2::new(x, y)))
-                .filter(|p| Neighbors::is_corner(image, p.x, p.y))
+                .filter(|p| {
+                    *image.get_pixel(p.x, p.y) && Neighbors::from_image(image, p.x, p.y).is_corner()
+                })
                 .collect(),
         }
     }
@@ -45,11 +47,11 @@ where
             let mut current = start;
             let mut object = vec![start];
 
-            let neighbors = Neighbors::get_neighbors(self.image, start.x, start.y);
+            let neighbors = Neighbors::from_image(self.image, start.x, start.y);
             let mut previous_direction = Direction::next_direction(None, neighbors);
 
             loop {
-                let neighbors = Neighbors::get_neighbors(self.image, current.x, current.y);
+                let neighbors = Neighbors::from_image(self.image, current.x, current.y);
                 let direction = Direction::next_direction(Some(previous_direction), neighbors);
 
                 current = if previous_direction.reverse() == direction {

--- a/src/iter/utils.rs
+++ b/src/iter/utils.rs
@@ -1,16 +1,7 @@
-use crate::UVec2;
-
-// Get the bounding box of the polygon
-pub fn bounding_box(polygon: &[UVec2]) -> Option<(UVec2, UVec2)> {
-    polygon
-        .iter()
-        .copied()
-        .zip(polygon.iter().copied())
-        .reduce(|(min, max), (a, b)| (min.min(a), max.max(b)))
-}
+use crate::{utils::bounding_box, UVec2};
 
 pub fn in_polygon(x: u32, y: u32, polygon: &[UVec2]) -> bool {
-    if let Some((min, max)) = bounding_box(polygon) {
+    if let Some((min, max)) = bounding_box(polygon.iter().copied()) {
         // Check if the is within the bounding box
         if x < min.x || x > max.x || y < min.y || y > max.y {
             return false; // Early exit if outside the bounding box

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ where
     pub fn single_translated(&self) -> Option<Vec<Vec2>> {
         self.iter()
             .next()
-            .map(|polygon| anchor::Anchor::Center(self.height(), self.width()).translate(polygon))
+            .map(|polygon| self.anchor().translate(polygon))
     }
 
     /// Retrieves the raw edge points of a single image.
@@ -60,7 +60,7 @@ where
     #[inline]
     #[must_use]
     pub fn multi_translated(&self) -> Vec<Vec<Vec2>> {
-        anchor::Anchor::Center(self.height(), self.width()).translate_polygons(self.iter())
+        self.anchor().translate_polygons(self.iter())
     }
 
     /// Retrieves the raw edge points of multiple images.
@@ -78,6 +78,12 @@ where
     #[must_use]
     pub fn iter(&self) -> iter::Edges<I> {
         self.into_iter()
+    }
+
+    #[inline]
+    #[must_use]
+    fn anchor(&self) -> anchor::Anchor {
+        anchor::Anchor::Center(self.height(), self.width())
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,8 +8,12 @@ pub fn bounding_box(polygon: impl Iterator<Item = UVec2>) -> Option<(UVec2, UVec
 }
 
 #[inline]
-pub fn center_of(polygon: impl Iterator<Item = UVec2>) -> Option<Vec2> {
-    bounding_box(polygon)
-        .map(|(min, max)| (min.as_vec2(), max.as_vec2()))
-        .map(|(min, max)| min + (max - min) / 2.)
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn center_of(polygon: &[UVec2]) -> Option<Vec2> {
+    polygon
+        .iter()
+        .copied()
+        .reduce(|acc, p| acc + p)
+        .map(|sum| (sum / polygon.len() as u32).as_vec2())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
-use crate::UVec2;
+use crate::{UVec2, Vec2};
 
-// Get the bounding box of the polygon
+#[inline]
 pub fn bounding_box(polygon: impl Iterator<Item = UVec2>) -> Option<(UVec2, UVec2)> {
     polygon
         .map(|p| (p, p))
@@ -8,7 +8,8 @@ pub fn bounding_box(polygon: impl Iterator<Item = UVec2>) -> Option<(UVec2, UVec
 }
 
 #[inline]
-#[must_use]
-pub fn center(polygon: impl Iterator<Item = UVec2>) -> Option<UVec2> {
-    bounding_box(polygon).map(|(min, max)| min + (max - min) / 2)
+pub fn center_of(polygon: impl Iterator<Item = UVec2>) -> Option<Vec2> {
+    bounding_box(polygon)
+        .map(|(min, max)| (min.as_vec2(), max.as_vec2()))
+        .map(|(min, max)| min + (max - min) / 2.)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,43 +1,14 @@
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
+use crate::UVec2;
 
-use crate::{UVec2, Vec2};
-
-/// Translates an `Vec` of points in positive (x, y) coordinates to a coordinate system centered at (0, 0).
-///
-/// # Returns
-///
-/// A vector of `Vec2` representing the translated coordinates.
-#[inline]
-#[must_use]
-pub fn translate(polygon: Vec<UVec2>, width: u32, height: u32) -> Vec<Vec2> {
-    #[cfg(feature = "parallel")]
-    let iter = polygon.into_par_iter();
-    #[cfg(not(feature = "parallel"))]
-    let iter = polygon.into_iter();
-
-    let d = UVec2::new(width, height) / 2;
-    iter.map(|p| {
-        let (x, y) = (p.x.abs_diff(d.x) as f32, p.y.abs_diff(d.y) as f32);
-        let cmp = p.cmplt(d);
-        Vec2::new(if cmp.x { -x } else { x }, if cmp.y { y } else { -y })
-    })
-    .collect()
+// Get the bounding box of the polygon
+pub fn bounding_box(polygon: impl Iterator<Item = UVec2>) -> Option<(UVec2, UVec2)> {
+    polygon
+        .map(|p| (p, p))
+        .reduce(|(min, max), (a, b)| (min.min(a), max.max(b)))
 }
 
-/// Translates an `Vec` of `Vec` of points in positive (x, y) coordinates to a coordinate system centered at (0, 0).
-///
-/// # Returns
-///
-/// A vector of vector of `Vec2` representing the translated objects.
 #[inline]
 #[must_use]
-pub fn translate_objects(
-    polygons: impl Iterator<Item = Vec<UVec2>>,
-    width: u32,
-    height: u32,
-) -> Vec<Vec<Vec2>> {
-    polygons
-        .map(|polygon| translate(polygon, width, height))
-        .collect()
+pub fn center(polygon: impl Iterator<Item = UVec2>) -> Option<UVec2> {
+    bounding_box(polygon).map(|(min, max)| min + (max - min) / 2)
 }


### PR DESCRIPTION
## Changes

### Added

- public `anchor` module ([f2c4560](https://github.com/shnewto/edges/commit/f3c4560ca1bd5209155d632e36e0be374b915947)).
  - Enumeration `Anchor`:
    - `Center` for translate points by center of rect.
    - `Vertical` | `Horizontal` center to translate points by center of line.
    - `Absolute` center for translate points by center of her bounding box.
- `utils` module marked public ([f2c4560](https://github.com/shnewto/edges/commit/f3c4560ca1bd5209155d632e36e0be374b915947)).
- `utils::center_of` function for get center of polygon ([03165ca](https://github.com/shnewto/edges/commit/03165cabc3a9b384703c47e3d1855d357c6380e7)).
- `utils::bounding_box` function for get bounding box of polygon ([f2c4560](https://github.com/shnewto/edges/commit/f3c4560ca1bd5209155d632e36e0be374b915947)).

### Changed

- Upgrade dependencies: `binary_image` 0.6 ([159761a](https://github.com/shnewto/edges/commit/159761a1be6fb494d3d2295f4885e535d65cccc2)).
- `utils::translate` function moved to `anchor::Anchor` implementation ([f2c4560](https://github.com/shnewto/edges/commit/f3c4560ca1bd5209155d632e36e0be374b915947)).
- `utils::translate_objects` function renamed to `translate_polygons` and moved to `anchor::Anchor` ([f2c4560](https://github.com/shnewto/edges/commit/f3c4560ca1bd5209155d632e36e0be374b915947)).